### PR TITLE
Improve short video interactions

### DIFF
--- a/app/src/main/java/com/vhn/doan/data/ShortVideo.java
+++ b/app/src/main/java/com/vhn/doan/data/ShortVideo.java
@@ -1,5 +1,6 @@
 package com.vhn.doan.data;
 
+import com.google.firebase.database.Exclude;
 import com.google.firebase.database.PropertyName;
 import com.vhn.doan.services.CloudinaryVideoHelper;
 import java.util.Map;
@@ -42,6 +43,9 @@ public class ShortVideo {
 
     @PropertyName("userId")
     private String userId;
+
+    @Exclude
+    private boolean likedByCurrentUser;
 
     // Constructor mặc định cần thiết cho Firebase
     public ShortVideo() {
@@ -151,6 +155,16 @@ public class ShortVideo {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    @Exclude
+    public boolean isLikedByCurrentUser() {
+        return likedByCurrentUser;
+    }
+
+    @Exclude
+    public void setLikedByCurrentUser(boolean likedByCurrentUser) {
+        this.likedByCurrentUser = likedByCurrentUser;
     }
 
     /**

--- a/app/src/main/java/com/vhn/doan/data/VideoComment.java
+++ b/app/src/main/java/com/vhn/doan/data/VideoComment.java
@@ -1,0 +1,43 @@
+package com.vhn.doan.data;
+
+/**
+ * Model đơn giản đại diện cho bình luận video
+ */
+public class VideoComment {
+    private String userId;
+    private String comment;
+    private long timestamp;
+
+    public VideoComment() {
+    }
+
+    public VideoComment(String userId, String comment, long timestamp) {
+        this.userId = userId;
+        this.comment = comment;
+        this.timestamp = timestamp;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/app/src/main/java/com/vhn/doan/data/repository/ShortVideoRepository.java
+++ b/app/src/main/java/com/vhn/doan/data/repository/ShortVideoRepository.java
@@ -47,6 +47,14 @@ public interface ShortVideoRepository {
     void updateLikeCount(String videoId, boolean isLiked, RepositoryCallback<Void> callback);
 
     /**
+     * Thêm bình luận cho video
+     * @param videoId ID của video
+     * @param comment Đối tượng bình luận
+     * @param callback Callback xử lý kết quả
+     */
+    void addComment(String videoId, com.vhn.doan.data.VideoComment comment, RepositoryCallback<Void> callback);
+
+    /**
      * Lấy sở thích người dùng từ preferences và user_topics
      * @param userId ID của người dùng
      * @param callback Callback để xử lý kết quả

--- a/app/src/main/java/com/vhn/doan/data/repository/ShortVideoRepositoryImpl.java
+++ b/app/src/main/java/com/vhn/doan/data/repository/ShortVideoRepositoryImpl.java
@@ -202,6 +202,18 @@ public class ShortVideoRepositoryImpl implements ShortVideoRepository {
     }
 
     @Override
+    public void addComment(String videoId, com.vhn.doan.data.VideoComment comment, RepositoryCallback<Void> callback) {
+        DatabaseReference commentsRef = videosRef.child(videoId).child("comments").push();
+        commentsRef.setValue(comment).addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                callback.onSuccess(null);
+            } else {
+                callback.onError("Không thể thêm bình luận");
+            }
+        });
+    }
+
+    @Override
     public void getUserPreferences(String userId, RepositoryCallback<Map<String, Float>> callback) {
         Map<String, Float> combinedPreferences = new HashMap<>();
 

--- a/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoAdapter.java
+++ b/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoAdapter.java
@@ -1,14 +1,18 @@
 package com.vhn.doan.presentation.shortvideo;
 
+import android.animation.ObjectAnimator;
 import android.graphics.Matrix;
 import android.graphics.SurfaceTexture;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.view.GestureDetector;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -88,7 +92,9 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
 
     public void updateVideoLike(int position, boolean isLiked, int newLikeCount) {
         if (position >= 0 && position < videos.size()) {
-            videos.get(position).setLikeCount(newLikeCount);
+            ShortVideo video = videos.get(position);
+            video.setLikeCount(newLikeCount);
+            video.setLikedByCurrentUser(isLiked);
             notifyItemChanged(position, "like_update");
         }
     }
@@ -167,6 +173,8 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
         private ImageView btnLike;
         private ImageView btnShare;
         private ImageView btnComment;
+        private FrameLayout rootLayout;
+        private GestureDetector gestureDetector;
 
         private boolean isLiked = false;
         private boolean isVideoLoaded = false;
@@ -176,6 +184,7 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
         public VideoViewHolder(@NonNull View itemView) {
             super(itemView);
             initViews();
+            setupGestureDetector();
             setupClickListeners();
             setupTextureView();
         }
@@ -192,10 +201,41 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
             btnLike = itemView.findViewById(R.id.btnLike);
             btnShare = itemView.findViewById(R.id.btnShare);
             btnComment = itemView.findViewById(R.id.btnComment);
+            rootLayout = (FrameLayout) itemView;
         }
 
         private void setupTextureView() {
             textureView.setSurfaceTextureListener(this);
+        }
+
+        private void setupGestureDetector() {
+            gestureDetector = new GestureDetector(itemView.getContext(), new GestureDetector.SimpleOnGestureListener() {
+                @Override
+                public boolean onDown(MotionEvent e) {
+                    return true;
+                }
+
+                @Override
+                public boolean onSingleTapConfirmed(MotionEvent e) {
+                    togglePlayPause();
+                    return true;
+                }
+
+                @Override
+                public boolean onDoubleTap(MotionEvent e) {
+                    showHeartAnimation(e.getX(), e.getY());
+                    if (!isLiked && listener != null) {
+                        int position = getAdapterPosition();
+                        if (position != RecyclerView.NO_POSITION) {
+                            ShortVideo video = videos.get(position);
+                            listener.onVideoLiked(position, video.getId(), isLiked);
+                        }
+                    }
+                    return true;
+                }
+            });
+
+            textureView.setOnTouchListener((v, event) -> gestureDetector.onTouchEvent(event));
         }
 
         // Implement TextureView.SurfaceTextureListener
@@ -305,8 +345,7 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
         }
 
         private void setupClickListeners() {
-            // Click video để play/pause
-            textureView.setOnClickListener(v -> togglePlayPause());
+            // Click video play/pause handled by gesture detector
             imgPlayPause.setOnClickListener(v -> togglePlayPause());
 
             // Click like button
@@ -352,6 +391,8 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
             txtCaption.setText(video.getCaption());
             txtViewCount.setText(formatCount(video.getViewCount()) + " lượt xem");
             txtLikeCount.setText(formatCount(video.getLikeCount()));
+            isLiked = video.isLikedByCurrentUser();
+            updateLikeButton();
 
             // Format ngày upload
             SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy", Locale.getDefault());
@@ -392,6 +433,7 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
             for (Object payload : payloads) {
                 if ("like_update".equals(payload)) {
                     txtLikeCount.setText(formatCount(video.getLikeCount()));
+                    isLiked = video.isLikedByCurrentUser();
                     updateLikeButton();
                 } else if ("view_update".equals(payload)) {
                     txtViewCount.setText(formatCount(video.getViewCount()) + " lượt xem");
@@ -549,6 +591,38 @@ public class ShortVideoAdapter extends RecyclerView.Adapter<ShortVideoAdapter.Vi
             if (textureView != null) {
                 textureView.setVisibility(View.GONE);
             }
+        }
+
+        private void showHeartAnimation(float x, float y) {
+            if (rootLayout == null) return;
+            ImageView heart = new ImageView(itemView.getContext());
+            heart.setImageResource(R.drawable.ic_heart_filled);
+            heart.setColorFilter(itemView.getContext().getResources().getColor(R.color.color_like));
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+            params.leftMargin = (int) x - 50;
+            params.topMargin = (int) y - 100;
+            rootLayout.addView(heart, params);
+
+            heart.setScaleX(0f);
+            heart.setScaleY(0f);
+            ObjectAnimator scaleX = ObjectAnimator.ofFloat(heart, View.SCALE_X, 1f);
+            ObjectAnimator scaleY = ObjectAnimator.ofFloat(heart, View.SCALE_Y, 1f);
+            ObjectAnimator alpha = ObjectAnimator.ofFloat(heart, View.ALPHA, 0f);
+            ObjectAnimator translate = ObjectAnimator.ofFloat(heart, View.TRANSLATION_Y, -200f);
+            scaleX.setDuration(600);
+            scaleY.setDuration(600);
+            alpha.setDuration(600);
+            translate.setDuration(600);
+            scaleX.start();
+            scaleY.start();
+            translate.start();
+            alpha.start();
+            alpha.addListener(new android.animation.AnimatorListenerAdapter() {
+                @Override
+                public void onAnimationEnd(android.animation.Animator animation) {
+                    rootLayout.removeView(heart);
+                }
+            });
         }
 
         private void updateLikeButton() {

--- a/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoContract.java
+++ b/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoContract.java
@@ -115,6 +115,11 @@ public interface ShortVideoContract {
         void filterVideosByTag(String tag);
 
         /**
+         * Thêm bình luận cho video
+         */
+        void addComment(String videoId, String commentText);
+
+        /**
          * Get video at position
          */
         ShortVideo getVideoAt(int position);

--- a/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoPresenter.java
+++ b/app/src/main/java/com/vhn/doan/presentation/shortvideo/ShortVideoPresenter.java
@@ -169,6 +169,7 @@ public class ShortVideoPresenter implements ShortVideoContract.Presenter {
 
         // Cập nhật dữ liệu local
         video.setLikeCount(newLikeCount);
+        video.setLikedByCurrentUser(newLikedState);
 
         if (view != null) {
             view.updateVideoLike(position, newLikedState, newLikeCount);
@@ -187,6 +188,7 @@ public class ShortVideoPresenter implements ShortVideoContract.Presenter {
                 boolean originalState = !newLikedState;
                 int originalCount = originalState ? video.getLikeCount() + 1 : Math.max(0, video.getLikeCount() - 1);
                 video.setLikeCount(originalCount);
+                video.setLikedByCurrentUser(originalState);
 
                 if (view != null) {
                     view.updateVideoLike(position, originalState, originalCount);
@@ -274,6 +276,38 @@ public class ShortVideoPresenter implements ShortVideoContract.Presenter {
                 view.showVideos(filteredVideos);
             }
         }
+    }
+
+    @Override
+    public void addComment(String videoId, String commentText) {
+        if (currentUserId == null || commentText == null || commentText.trim().isEmpty()) {
+            if (view != null) {
+                view.showError("Không thể gửi bình luận");
+            }
+            return;
+        }
+
+        com.vhn.doan.data.VideoComment comment = new com.vhn.doan.data.VideoComment(
+                currentUserId,
+                commentText,
+                System.currentTimeMillis()
+        );
+
+        repository.addComment(videoId, comment, new RepositoryCallback<Void>() {
+            @Override
+            public void onSuccess(Void result) {
+                if (view != null) {
+                    view.showSuccess("Đã gửi bình luận");
+                }
+            }
+
+            @Override
+            public void onError(String error) {
+                if (view != null) {
+                    view.showError("Không thể gửi bình luận");
+                }
+            }
+        });
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,9 @@
     <string name="video_unliked">Đã bỏ thích video</string>
     <string name="video_shared">Đã chia sẻ video</string>
     <string name="comment_feature_coming_soon">Chức năng bình luận sẽ được phát triển trong tương lai</string>
+    <string name="enter_comment">Nhập bình luận</string>
+    <string name="send_comment">Gửi</string>
+    <string name="share_video">Chia sẻ video</string>
     <string name="view_user_profile">Xem thông tin người đăng</string>
     <string name="error_loading_videos">Không thể tải video. Vui lòng thử lại.</string>
     <string name="trending_videos">Video thịnh hành</string>


### PR DESCRIPTION
## Summary
- Save video comments to Firebase and show input dialog
- Enable sharing videos via Android share intent
- Fix like/unlike logic and add double-tap heart animation
- Hide video view on fragment destruction to prevent flicker

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e68ce69483218a19bde92431f165